### PR TITLE
fix : start_date, end_date 잘못된 타입으로 인한 빌드 오류 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Set CI Environment to start Mock Server
-        run: echo "ACTIVATE_MOCK_SERVER=true" >> .env
-
       - name: Set Environment Variables
         run: |
           echo "NEXT_BOOK_NARU_API_KEY=${{ secrets.NEXT_BOOK_NARU_API_KEY }}" >> .env

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,19 +1,18 @@
+import { BooksInfinityCarousel } from '@/components';
 import { BOOK_LIST_MOCK_DATA } from '@/mocks/mockData';
 
 import BookListSection from './_components/BookListSection';
-import BooksCarouselSection from './_components/BooksCarouselSection';
 import { getLastMonthLibrarianPick } from './_services';
 import styles from './page.module.scss';
 
 const Home = async () => {
-  const librarianPickBooks = await getLastMonthLibrarianPick();
-
   const hotBooks = BOOK_LIST_MOCK_DATA;
+  const lastMonthLibrarianPick = await getLastMonthLibrarianPick();
 
   return (
     <div className={styles.homeContainer}>
       <h1 className="sr-only">BOOKER 홈페이지</h1>
-      <BooksCarouselSection.Loaded title="사서 추천 도서" booksSimpleInfo={librarianPickBooks} />
+      <BooksInfinityCarousel.Loaded title="사서 추천 도서" booksSimpleInfo={lastMonthLibrarianPick} />
       <BookListSection.Loaded title="대출 급상승! 도서" bookItemsData={hotBooks} />
       <BookListSection.Loaded title="다독자를 위한 추천 도서" bookItemsData={hotBooks} />
     </div>

--- a/src/services/books/librarianPick.ts
+++ b/src/services/books/librarianPick.ts
@@ -1,5 +1,4 @@
 import { ERROR_MESSAGE, ERROR_NAME } from '@/constants';
-import { BOOK_SIMPLE_INFO_LIST_MOCK_DATA } from '@/mocks/mockData';
 import { ApiLibrarianPickData, BookSimpleInfo } from '@/types';
 import { extractPlainTextFromXML, getLastMonthDates, parseXmlToJson, throwRequestError } from '@/utils';
 
@@ -15,10 +14,7 @@ export const makeLastMonthLibrarianPickUrl = () => {
  */
 export const fetchLastMonthLibrarianPick = async () => {
   // NOTE: 변경 사항이 없는 지난 달 사서 추천 도서 목록을 가져오는 것이므로 캐시를 강제함
-  const response = await fetch(makeLastMonthLibrarianPickUrl(), {
-    cache: 'force-cache',
-  });
-
+  const response = await fetch(makeLastMonthLibrarianPickUrl(), { cache: 'force-cache' });
   if (!response.ok) {
     throwRequestError({
       statusCode: response.status,
@@ -29,7 +25,6 @@ export const fetchLastMonthLibrarianPick = async () => {
 
   return response;
 };
-
 /**
  * 지난달 사서 추천 도서 목록 접근 권한 오류 처리
  * @param data 지난달 사서 추천 도서 목록 데이터
@@ -88,13 +83,6 @@ export const parseLastMonthLibrarianPick = async (response: Response) => {
 
   if ('error' in data) {
     handleLastMonthLibrarianPickError(data);
-  }
-
-  // 데이터에 channel이 존재하지 않거나 channel의 list가 존재하지 않는 경우 오류 처리
-  const isListEmpty = 'channel' in data && !('list' in data.channel);
-  // CI시, list가 없는 캐싱된 데이터로 인해 오류 발생을 방지하기 위해, 모킹 데이터 반환
-  if (isListEmpty && process.env.ACTIVATE_MOCK_SERVER) {
-    return BOOK_SIMPLE_INFO_LIST_MOCK_DATA;
   }
 
   return formatLastMonthLibrarianPick(data);

--- a/src/services/endpoints/publicLibraryEndpoint.ts
+++ b/src/services/endpoints/publicLibraryEndpoint.ts
@@ -1,8 +1,8 @@
 export const PUBLIC_LIBRARY_API_BASE_URL = 'https://nl.go.kr/NL/search/openApi';
 
 export interface GetLibrarianPickParams {
-  startDate: string;
-  endDate: string;
+  startDate: number;
+  endDate: number;
 }
 /**
  * 국립 중앙 도서관 - 사서 추천 도서 목록 요청 파라미터
@@ -18,8 +18,8 @@ const getLibrarianPickParams = ({ startDate, endDate }: GetLibrarianPickParams) 
 
   return new URLSearchParams({
     key: process.env.NEXT_PUBLIC_BOOK_LIBRARY_API_KEY || '',
-    start_date: startDate,
-    end_date: endDate,
+    start_date: startDate.toString(),
+    end_date: endDate.toString(),
     ...LIBRARIAN_ROW,
   }).toString();
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,12 +1,16 @@
+const formatDateToInt = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return parseInt(`${year}${month}${day}`, 10);
+};
+
 export const getLastMonthDates = () => {
   const today = new Date();
   const firstDay = new Date(today.getFullYear(), today.getMonth() - 1, 1);
   const lastDay = new Date(today.getFullYear(), today.getMonth(), 0);
-
-  const formatDate = (date: Date) => date.toISOString().split('T')[0]; // YYYY-MM-DD 형식으로 변환
-
   return {
-    firstDay: formatDate(firstDay),
-    lastDay: formatDate(lastDay),
+    firstDay: formatDateToInt(firstDay),
+    lastDay: formatDateToInt(lastDay),
   };
 };


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
이 PR과 연결된 이슈 번호를 작성해주세요.  
**Closes #46**

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)
### Node.js에서 사서 추천 도서 API 요청 시 유효하지 않은 데이터를 받은 이유
- start_date, end_date 타입이 Int인데 `YYYY-MM-DD`형식의 string으로 받고 있었다.
- 로컬 환경과 Node.js의 시간대 타입이 달라서, 로컬 환경에서는 운이 좋게 list가 존재하는 데이터를 받아올 수 있었다.

#### 시도한 것들...🥲
- Node.js 서버 문제인 줄 알고, 렌더링 후 다시 서버에 fetch하는 방법을 시도
 -  홈페이지를 SSR로 변경, 서버 액션 + 클라이언트 컴포넌트로 클라이언트 컴포넌트 렌더링 시 fetch 시도
- dev 페이지에서 API 요청 URL, XML 값을 HTML에 찍어서 확인 -> 로컬과 Node.js에서 빌드된 `start_date`, `end_date`가 다르다는 것을 확인 -> 빌드 된 `start_date`, `end_date`로 데이터 요청 시 totalCount가 0이되는 것을  확인 -> API 문서에서 데이터 타입 확인

---

## 📚 구현하면서 학습한 내용 (What I Learned)
- 로컬과 Node.js의 시간대 타입의 기준이 다르다.
---

### 😊 코멘트 💬
- 문서를 잘 보자....
- 잠 못자고 3시간? 이것 저것 디버깅했다... 하면서 렌더링 방식에 따른 데이터 패칭의 여러 케이스를 생각해 봤다
- Vercel에서 Next.js 서버 캐시 찍는 기능 생겼으면 
