### PR TITLE
fix: 도서 목록 이미지 사이즈 일관되게 수정, 대출 데이터가 없는 도서 정보 처리

### DIFF
--- a/src/app/book/[isbn]/_components/BookDetails/components/BookCover/index.module.scss
+++ b/src/app/book/[isbn]/_components/BookDetails/components/BookCover/index.module.scss
@@ -42,9 +42,9 @@ $backdrop-filter-brightness: 110%;
   -webkit-box-shadow: 0px 0px 40px 6px rgba(9, 9, 9, 0.3);
   box-shadow: 0px 0px 40px 6px rgba(109, 108, 108, 0.3);
   border-radius: $img-border-radius;
+  aspect-ratio: 2/3;
 
   width: 20rem;
-  height: 32rem;
   img {
     border-radius: inherit;
   }

--- a/src/app/book/[isbn]/_components/BookDetails/components/BookCover/index.tsx
+++ b/src/app/book/[isbn]/_components/BookDetails/components/BookCover/index.tsx
@@ -24,6 +24,7 @@ const BookCoverLayout = ({ bookDetailData }: BookCoverLayoutProps) => {
             fill
             placeholder="blur"
             blurDataURL={gray200BlurDataURL}
+            quality={100}
           />
         ) : (
           <div className={styles.coverImageSkeleton}></div>

--- a/src/app/book/[isbn]/_components/BookDetails/components/BookOverview/index.tsx
+++ b/src/app/book/[isbn]/_components/BookDetails/components/BookOverview/index.tsx
@@ -11,11 +11,11 @@ interface BookOverviewLoadedProps {
 const BookOverviewLoaded = ({ bookDetailData }: BookOverviewLoadedProps) => {
   const { author, publisher, publicationYear, loans, title } = bookDetailData;
 
-  const bookSummary = [
-    `${author} 저자(글)`,
-    `${publisher}﹒${publicationYear}년`,
-    `대출 ${loans.rank}위 (${loans.count}건)`,
-  ];
+  const bookSummary = [`${author} 저자(글)`, `${publisher}﹒${publicationYear}년`];
+
+  if (loans.count && loans.rank) {
+    bookSummary.push(`대출 ${loans.rank}위 (${loans.count}건)`);
+  }
 
   return (
     <div className={styles.bookOverview}>

--- a/src/components/ScrollObserver/index.tsx
+++ b/src/components/ScrollObserver/index.tsx
@@ -7,7 +7,7 @@ const ScrollObserver = (props: UseFetchBooksActionProps) => {
   const { fetchMoreBooksAction, isPending, isLastPage } = useFetchBooksAction(props);
   const { observerTargetRef } = useObserver({ isLastPage, isPending, fetchMoreBooksAction });
 
-  return <>{!isLastPage && <div ref={observerTargetRef} style={{ height: '1px' }} />}</>;
+  return <>{!isLastPage && <div ref={observerTargetRef} style={{ minHeight: '1px' }} />}</>;
 };
 
 export default ScrollObserver;

--- a/src/components/book/BookCover/index.module.scss
+++ b/src/components/book/BookCover/index.module.scss
@@ -4,9 +4,10 @@
 .imgWrapper {
   position: relative;
   aspect-ratio: 2/3;
-
   & > img {
     border-radius: var(--book-cover-border-radius);
+    width: inherit;
+    height: auto;
   }
 }
 

--- a/src/components/book/BookCover/index.tsx
+++ b/src/components/book/BookCover/index.tsx
@@ -12,7 +12,7 @@ interface BookCoverLoadedProps {
   bookItemData: BookItemData;
 }
 
-const BookCoverLoaded = ({ bookItemData, classNameForWidth, imgWidth = 400 }: BookCoverLoadedProps) => {
+const BookCoverLoaded = ({ bookItemData, classNameForWidth, imgWidth = 100 }: BookCoverLoadedProps) => {
   return (
     <div className={classNames(styles.imgWrapper, classNameForWidth)}>
       <Image
@@ -22,6 +22,7 @@ const BookCoverLoaded = ({ bookItemData, classNameForWidth, imgWidth = 400 }: Bo
         alt=""
         width={imgWidth}
         height={(imgWidth * 3) / 2}
+        quality={100}
       />
     </div>
   );

--- a/src/components/book/BookCover/index.tsx
+++ b/src/components/book/BookCover/index.tsx
@@ -6,13 +6,13 @@ import NoCoverImg from '@/images/noCover.svg';
 import { BookItemData } from '@/types';
 
 import styles from './index.module.scss';
-
 interface BookCoverLoadedProps {
+  imgWidth?: number;
   classNameForWidth: string;
   bookItemData: BookItemData;
 }
 
-const BookCoverLoaded = ({ bookItemData, classNameForWidth }: BookCoverLoadedProps) => {
+const BookCoverLoaded = ({ bookItemData, classNameForWidth, imgWidth = 400 }: BookCoverLoadedProps) => {
   return (
     <div className={classNames(styles.imgWrapper, classNameForWidth)}>
       <Image
@@ -20,7 +20,8 @@ const BookCoverLoaded = ({ bookItemData, classNameForWidth }: BookCoverLoadedPro
         placeholder="blur"
         blurDataURL={gray200BlurDataURL}
         alt=""
-        fill
+        width={imgWidth}
+        height={(imgWidth * 3) / 2}
       />
     </div>
   );

--- a/src/components/book/BookItem/_variables.scss
+++ b/src/components/book/BookItem/_variables.scss
@@ -1,2 +1,2 @@
 $img__width-basic: 8rem;
-$img__width-small: 7rem;
+$img__width-small: 6rem;

--- a/src/components/carousel/SwipeableCarousel/components/SwipeableBookCard/index.module.scss
+++ b/src/components/carousel/SwipeableCarousel/components/SwipeableBookCard/index.module.scss
@@ -1,6 +1,7 @@
 @use '@/styles/mixins' as mixins;
 
 $img__width-basic: 10rem;
+$img__width-small: 7rem;
 
 .container {
   display: flex;
@@ -8,10 +9,18 @@ $img__width-basic: 10rem;
   align-items: center;
   gap: 1rem;
   width: $img__width-basic;
+
+  @media screen and (max-width: 425px) {
+    width: $img__width-small;
+  }
 }
 
 .cover {
   width: $img__width-basic;
+
+  @media screen and (max-width: 425px) {
+    width: $img__width-small;
+  }
 }
 
 .bookInfo {

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -77,7 +77,6 @@ a:not([class]) {
 img,
 picture {
   display: block;
-  max-width: 100%;
 }
 
 /* Inherit fonts for inputs and buttons */


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
이 PR과 연결된 이슈 번호를 작성해주세요.  
**Closes #70**

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)
### 대출 데이터가 없는 도서 정보 처리
- 도서 상세 페이지에서 해당 도서에 대한 대출 정보가 없다면, 대출 관련 ui를 렌더링 하지 않는 방식으로 변경

### 이미지 사이즈 수정
문제 : 도서 커버 이미지 sizes 방식, 커버 비율들이 일관적이지 않아서, wrapper의 이미지 기준으로 'fill + wdith:100%'으로 했을 때 도서 목록에서 이미지 사이즈가 맞지 않는 오류가 발생

해결 : 'Image width 설정 + width:inherit' 
- BookItem/BookCover에 imgWidth를 props로 추가하고, 도서 목록에서 필요한 이미지 width를 기본값으로 설정, height는 2/3 비율로 계산해 적용
- reset.css에서 이미지가 inline-block으로 되어 있어서, width:100%이 아닌 inherit으로 설정해야, wrapper 너비에 맞게 적용됨

<수정 전>
<img width="422" alt="스크린샷 2025-02-14 오전 11 29 46" src="https://github.com/user-attachments/assets/709b1c67-9358-4e67-9ef2-279a94a028ba" />


<수정 후>
<img width="422" alt="스크린샷 2025-02-14 오전 11 30 00" src="https://github.com/user-attachments/assets/bf25eedc-963b-4e49-8042-0134e0cc1a35" />

### 도서 상세 페이지, 추천 도서 커버 이미지 사이즈 수정
- 425px 이하의 뷰에서 도서 커버 이미지를 좀 더 작게 수정 

---

## 📚 구현하면서 학습한 내용 (What I Learned)


---

### 😊 코멘트 💬
- 도서 목록의 도서 커버 이미지 조정 시, 뷰 포트 사이즈 조정 시 마다 with,height를 조정하는 방법등 여러가기를 시도해봤다. 그러나, 성능 최적화를 위해서 사용하는 Image 컴포넌트인데, 뷰 포트마다 상태가 변하는 방식은 성능상 마이너스가 된다고 생각해 하지 않았다. 
