### PR TITLE
fix: 모달 웹 접근성 개선

### DIFF
--- a/src/app/@modal/(.)book/[isbn]/page.tsx
+++ b/src/app/@modal/(.)book/[isbn]/page.tsx
@@ -1,16 +1,22 @@
 import { Suspense } from 'react';
 
+import { getBookDetails } from '@/app/book/[isbn]/_services/book';
 import BookDetailsLoading from '@/app/book/[isbn]/loading';
 import BookDetailsPage, { BookDetailsPageParams } from '@/app/book/[isbn]/page';
 import { FullScreenModal } from '@/components';
 
 const BookDetailsModal = async ({ params }: BookDetailsPageParams) => {
+  const { isbn } = await params;
+  const bookDetailData = await getBookDetails(isbn);
+
   return (
-    <FullScreenModal a11yMessage="도서 상세 정보 모달">
-      <Suspense fallback={<BookDetailsLoading />}>
-        <BookDetailsPage params={params} />
-      </Suspense>
-    </FullScreenModal>
+    <>
+      <FullScreenModal a11yMessage={`${bookDetailData.title}도서 상세 정보 모달`}>
+        <Suspense fallback={<BookDetailsLoading />}>
+          <BookDetailsPage params={params} />
+        </Suspense>
+      </FullScreenModal>
+    </>
   );
 };
 

--- a/src/app/@modal/(.)book/[isbn]/page.tsx
+++ b/src/app/@modal/(.)book/[isbn]/page.tsx
@@ -6,7 +6,7 @@ import { FullScreenModal } from '@/components';
 
 const BookDetailsModal = async ({ params }: BookDetailsPageParams) => {
   return (
-    <FullScreenModal>
+    <FullScreenModal a11yMessage="도서 상세 정보 모달">
       <Suspense fallback={<BookDetailsLoading />}>
         <BookDetailsPage params={params} />
       </Suspense>

--- a/src/app/book/[isbn]/_components/BookDetails/index.tsx
+++ b/src/app/book/[isbn]/_components/BookDetails/index.tsx
@@ -12,21 +12,21 @@ interface BookDetailProps {
 
 const BookDetailsLoaded = ({ bookDetailData }: BookDetailProps) => {
   return (
-    <article className={styles.container}>
+    <section className={styles.container}>
       <BookCover.Loaded bookDetailData={bookDetailData} />
       <BookOverview.Loaded bookDetailData={bookDetailData} />
       <BookDescription.Loaded bookDetailData={bookDetailData} />
-    </article>
+    </section>
   );
 };
 
 const BookDetailsSkeleton = () => {
   return (
-    <article className={classNames(styles.container, styles.containerSkeleton)}>
+    <section className={classNames(styles.container, styles.containerSkeleton)}>
       <BookCover.Skeleton />
       <BookOverview.Skeleton />
       <BookDescription.Skeleton />
-    </article>
+    </section>
   );
 };
 

--- a/src/components/common/A11yMessage.tsx
+++ b/src/components/common/A11yMessage.tsx
@@ -1,0 +1,13 @@
+interface A11MessageProps {
+  isHidden: boolean;
+  message: string;
+}
+const A11yMessage = ({ isHidden, message }: A11MessageProps) => {
+  return (
+    <p className="sr-only" aria-live="assertive" aria-hidden={isHidden} aria-atomic="true">
+      {message}
+    </p>
+  );
+};
+
+export default A11yMessage;

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -3,3 +3,4 @@ export { default as NotFound } from './NotFound';
 export { default as HomeButton } from './HomeButton';
 export { default as NoBooksYet } from './NoBooksYet';
 export { default as H1 } from './H1';
+export { default as A11yMessage } from './A11yMessage';

--- a/src/components/overlay/FullScreenModal/index.tsx
+++ b/src/components/overlay/FullScreenModal/index.tsx
@@ -11,8 +11,9 @@ import styles from './index.module.scss';
 
 interface FullScreenModalProps {
   children: React.ReactNode;
+  a11yMessage?: string;
 }
-const FullScreenModal = ({ children }: FullScreenModalProps) => {
+const FullScreenModal = ({ children, a11yMessage }: FullScreenModalProps) => {
   const htmlElement = document.querySelector('html');
 
   const router = useRouter();
@@ -29,7 +30,7 @@ const FullScreenModal = ({ children }: FullScreenModalProps) => {
   }, []);
 
   return (
-    <Portal handleClosePortal={handleClosePortal}>
+    <Portal a11yMessage={a11yMessage} handleClosePortal={handleClosePortal}>
       <div className={styles.container}>
         <div className={styles.inner}>
           <button aria-label="닫기" className={styles.closeButton} onClick={handleClosePortal}>

--- a/src/components/overlay/Portal/hooks/useClickPortal.ts
+++ b/src/components/overlay/Portal/hooks/useClickPortal.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface UseClickPortalProps {
+  modalRef: React.RefObject<HTMLDivElement | null>;
+  handleClosePortal?: () => void;
+}
+
+const useClickPortal = ({ modalRef, handleClosePortal }: UseClickPortalProps) => {
+  const handleClick = (e: MouseEvent) => {
+    if (!modalRef.current) return;
+    if (!(e.target instanceof HTMLElement)) return;
+
+    if (!modalRef.current.contains(e.target) && handleClosePortal) {
+      handleClosePortal();
+    }
+  };
+  useEffect(() => {
+    if (!handleClosePortal) return;
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      if (!handleClosePortal) return;
+      document.removeEventListener('click', handleClick);
+    };
+  }, []);
+};
+
+export default useClickPortal;

--- a/src/components/overlay/Portal/hooks/useKeydownPortal.ts
+++ b/src/components/overlay/Portal/hooks/useKeydownPortal.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface UseKeydownPortalProps {
+  portalRoot: HTMLElement | null;
+  modalRef: React.RefObject<HTMLDivElement | null>;
+  handleClosePortal?: () => void;
+}
+
+const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydownPortalProps) => {
+  const [focusableElements, setFocusableElements] = useState<NodeListOf<HTMLElement> | null>(null);
+
+  const updateFocusableElement = () => {
+    if (!modalRef.current) return;
+
+    const elements = modalRef.current.querySelectorAll<HTMLElement>(
+      'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
+    );
+
+    setFocusableElements(elements);
+  };
+
+  const focusFirstFocusableElement = () => {
+    if (!focusableElements || focusableElements.length === 0) return;
+    focusableElements[0].focus();
+  };
+
+  const handleTab = (e: KeyboardEvent) => {
+    if (!modalRef.current) return;
+    if (e.key !== 'Tab') return;
+    if (!focusableElements || focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.shiftKey && document.activeElement === firstElement) {
+      e.preventDefault();
+      lastElement.focus();
+
+      return;
+    }
+
+    if (document.activeElement === lastElement) {
+      e.preventDefault();
+      firstElement.focus();
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.code === 'Escape' && handleClosePortal) handleClosePortal();
+    handleTab(e);
+  };
+
+  useEffect(() => {
+    updateFocusableElement();
+  }, [portalRoot]);
+
+  useEffect(() => {
+    if (!handleClosePortal) return;
+    document.addEventListener('keydown', handleKeyDown);
+    focusFirstFocusableElement();
+
+    return () => {
+      if (!handleClosePortal) return;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [focusFirstFocusableElement]);
+};
+
+export default useKeydownPortal;

--- a/src/components/overlay/Portal/hooks/useKeydownPortal.ts
+++ b/src/components/overlay/Portal/hooks/useKeydownPortal.ts
@@ -9,7 +9,7 @@ interface UseKeydownPortalProps {
 }
 
 const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydownPortalProps) => {
-  const [focusableElements, setFocusableElements] = useState<NodeListOf<HTMLElement> | null>(null);
+  const [focusableElements, setFocusableElements] = useState<HTMLElement[] | null>(null);
   const focusCountRef = useRef(0);
   const updateFocusableElement = () => {
     if (!modalRef.current) return;
@@ -18,7 +18,7 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydow
       'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
     );
 
-    setFocusableElements(elements);
+    setFocusableElements([modalRef.current, ...elements]);
   };
 
   const handleTab = (e: KeyboardEvent) => {

--- a/src/components/overlay/Portal/hooks/useKeydownPortal.ts
+++ b/src/components/overlay/Portal/hooks/useKeydownPortal.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface UseKeydownPortalProps {
   portalRoot: HTMLElement | null;
@@ -10,7 +10,7 @@ interface UseKeydownPortalProps {
 
 const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydownPortalProps) => {
   const [focusableElements, setFocusableElements] = useState<NodeListOf<HTMLElement> | null>(null);
-
+  const focusCountRef = useRef(0);
   const updateFocusableElement = () => {
     if (!modalRef.current) return;
 
@@ -21,11 +21,6 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydow
     setFocusableElements(elements);
   };
 
-  const focusFirstFocusableElement = () => {
-    if (!focusableElements || focusableElements.length === 0) return;
-    focusableElements[0].focus();
-  };
-
   const handleTab = (e: KeyboardEvent) => {
     if (!modalRef.current) return;
     if (e.key !== 'Tab') return;
@@ -33,15 +28,14 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydow
 
     const firstElement = focusableElements[0];
     const lastElement = focusableElements[focusableElements.length - 1];
+    focusCountRef.current++;
 
     if (e.shiftKey && document.activeElement === firstElement) {
       e.preventDefault();
       lastElement.focus();
-
-      return;
     }
 
-    if (document.activeElement === lastElement) {
+    if (document.activeElement === lastElement || focusCountRef.current === 1) {
       e.preventDefault();
       firstElement.focus();
     }
@@ -59,13 +53,12 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydow
   useEffect(() => {
     if (!handleClosePortal) return;
     document.addEventListener('keydown', handleKeyDown);
-    focusFirstFocusableElement();
 
     return () => {
       if (!handleClosePortal) return;
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [focusFirstFocusableElement]);
+  }, [focusableElements]);
 };
 
 export default useKeydownPortal;

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -12,13 +12,15 @@ interface Props {
   handleClosePortal?: () => void;
   children: React.ReactNode;
   extraClassName?: string;
+  a11yMessage?: string;
 }
-const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
+const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage }: Props) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
   useKeydownPortal({ modalRef, portalRoot, handleClosePortal });
   useClickPortal({ modalRef, handleClosePortal });
+
   useEffect(() => {
     const root = document.getElementById('portal-root');
     setPortalRoot(root);
@@ -29,10 +31,19 @@ const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
   return createPortal(
     <div
       role="dialog"
-      aria-label="portal"
+      aria-label={'portal'}
       ref={modalRef}
       className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}
     >
+      {a11yMessage && (
+        <p
+          className="sr-only"
+          //eslint-disable-next-line
+          tabIndex={0}
+        >
+          {a11yMessage}
+        </p>
+      )}
       {children}
     </div>,
     portalRoot,

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -31,19 +31,12 @@ const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage }: Pr
   return createPortal(
     <div
       role="dialog"
-      aria-label={'portal'}
+      aria-label={a11yMessage ?? 'portal'}
       ref={modalRef}
       className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}
+      //eslint-disable-next-line
+      tabIndex={0}
     >
-      {a11yMessage && (
-        <p
-          className="sr-only"
-          //eslint-disable-next-line
-          tabIndex={0}
-        >
-          {a11yMessage}
-        </p>
-      )}
       {children}
     </div>,
     portalRoot,

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import useKeydownPortal from './hooks/useKeydownPortal';
 import styles from './index.module.scss';
 
 interface Props {
@@ -12,22 +13,20 @@ interface Props {
   extraClassName?: string;
 }
 const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
-  const divRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
+
   const handleClick = (e: MouseEvent) => {
-    if (!divRef.current) return;
+    if (!modalRef.current) return;
     if (!(e.target instanceof HTMLElement)) return;
 
-    if (!divRef.current.contains(e.target) && handleClosePortal) {
+    if (!modalRef.current.contains(e.target) && handleClosePortal) {
       handleClosePortal();
     }
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.code === 'Escape' && handleClosePortal) handleClosePortal();
-  };
-
+  useKeydownPortal({ modalRef, portalRoot, handleClosePortal });
   useEffect(() => {
     const root = document.getElementById('portal-root');
     setPortalRoot(root);
@@ -36,12 +35,10 @@ const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
   useEffect(() => {
     if (!handleClosePortal) return;
     document.addEventListener('click', handleClick);
-    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
       if (!handleClosePortal) return;
       document.removeEventListener('click', handleClick);
-      document.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
 
@@ -51,7 +48,7 @@ const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
     <div
       role="dialog"
       aria-label="portal"
-      ref={divRef}
+      ref={modalRef}
       className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}
     >
       {children}

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import useClickPortal from './hooks/useClickPortal';
 import useKeydownPortal from './hooks/useKeydownPortal';
 import styles from './index.module.scss';
 
@@ -16,30 +17,11 @@ const Portal = ({ handleClosePortal, children, extraClassName }: Props) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
-
-  const handleClick = (e: MouseEvent) => {
-    if (!modalRef.current) return;
-    if (!(e.target instanceof HTMLElement)) return;
-
-    if (!modalRef.current.contains(e.target) && handleClosePortal) {
-      handleClosePortal();
-    }
-  };
-
   useKeydownPortal({ modalRef, portalRoot, handleClosePortal });
+  useClickPortal({ modalRef, handleClosePortal });
   useEffect(() => {
     const root = document.getElementById('portal-root');
     setPortalRoot(root);
-  }, []);
-
-  useEffect(() => {
-    if (!handleClosePortal) return;
-    document.addEventListener('click', handleClick);
-
-    return () => {
-      if (!handleClosePortal) return;
-      document.removeEventListener('click', handleClick);
-    };
   }, []);
 
   if (!portalRoot) return null; // portal-root가 준비되지 않으면 렌더링하지 않음

--- a/src/components/overlay/Toast/index.tsx
+++ b/src/components/overlay/Toast/index.tsx
@@ -14,8 +14,9 @@ const DURATION = 3 * 1000;
 interface Props {
   children: React.ReactNode;
   handleCloseToast: () => void;
+  a11yMessage?: string;
 }
-const Toast = ({ children, handleCloseToast }: Props) => {
+const Toast = ({ children, handleCloseToast, a11yMessage }: Props) => {
   const timeout = setTimeout(() => {
     handleCloseToast();
   }, DURATION);
@@ -27,7 +28,7 @@ const Toast = ({ children, handleCloseToast }: Props) => {
   }, []);
 
   return (
-    <Portal>
+    <Portal a11yMessage={a11yMessage}>
       <div className={styles.toast}>
         <Image src={WarningIcon} alt="" width={16} />
         {children}

--- a/src/components/overlay/Toast/index.tsx
+++ b/src/components/overlay/Toast/index.tsx
@@ -14,7 +14,7 @@ const DURATION = 3 * 1000;
 interface Props {
   children: React.ReactNode;
   handleCloseToast: () => void;
-  a11yMessage?: string;
+  a11yMessage: string;
 }
 const Toast = ({ children, handleCloseToast, a11yMessage }: Props) => {
   const timeout = setTimeout(() => {

--- a/src/components/search/Searchbar/action/searchAction.tsx
+++ b/src/components/search/Searchbar/action/searchAction.tsx
@@ -10,15 +10,16 @@ export type ProcessSearchFunction = (params: ProcessSearchParams) => void | Prom
 const searchAction =
   (processSearch: ProcessSearchFunction) =>
   async (_: any, formData: FormData): Promise<ActionState> => {
-    const selectedCategory = formData?.get('selectedCategory');
-    const searchValue = formData?.get('searchValue');
-    if (!selectedCategory) return { status: false, error: '검색 유형을 찾지 못했어요' };
+    // const selectedCategory = formData?.get('selectedCategory');
+    // const searchValue = formData?.get('searchValue');
+    // if (!selectedCategory) return { status: false, error: '검색 유형을 찾지 못했어요' };
 
-    if (!searchValue) return { status: false, error: '검색어 찾지 못했어요' };
-    // TODO: 추후에 api 연동 추가
-    await processSearch({ selectedCategory, searchValue });
+    // if (!searchValue) return { status: false, error: '검색어 찾지 못했어요' };
+    // // TODO: 추후에 api 연동 추가
+    // await processSearch({ selectedCategory, searchValue });
 
-    return { status: true, error: '' };
+    // return { status: true, error: '' };
+    return { status: false, error: '검색 유형을 찾지 못했어요' };
   };
 
 export default searchAction;

--- a/src/components/search/Searchbar/action/searchAction.tsx
+++ b/src/components/search/Searchbar/action/searchAction.tsx
@@ -10,16 +10,15 @@ export type ProcessSearchFunction = (params: ProcessSearchParams) => void | Prom
 const searchAction =
   (processSearch: ProcessSearchFunction) =>
   async (_: any, formData: FormData): Promise<ActionState> => {
-    // const selectedCategory = formData?.get('selectedCategory');
-    // const searchValue = formData?.get('searchValue');
-    // if (!selectedCategory) return { status: false, error: '검색 유형을 찾지 못했어요' };
+    const selectedCategory = formData?.get('selectedCategory');
+    const searchValue = formData?.get('searchValue');
+    if (!selectedCategory) return { status: false, error: '검색 유형을 찾지 못했어요' };
 
-    // if (!searchValue) return { status: false, error: '검색어 찾지 못했어요' };
-    // // TODO: 추후에 api 연동 추가
-    // await processSearch({ selectedCategory, searchValue });
+    if (!searchValue) return { status: false, error: '검색어 찾지 못했어요' };
+    // TODO: 추후에 api 연동 추가
+    await processSearch({ selectedCategory, searchValue });
 
-    // return { status: true, error: '' };
-    return { status: false, error: '검색 유형을 찾지 못했어요' };
+    return { status: true, error: '' };
   };
 
 export default searchAction;

--- a/src/components/search/Searchbar/hooks/useToast.ts
+++ b/src/components/search/Searchbar/hooks/useToast.ts
@@ -7,7 +7,7 @@ interface Props {
 }
 const useToast = ({ state }: Props) => {
   const [isOpenToast, setIsOpenToast] = useState(false);
-
+  const [message, setMessage] = useState('');
   const handleCloseToast = () => setIsOpenToast(false);
 
   useEffect(() => {
@@ -15,7 +15,17 @@ const useToast = ({ state }: Props) => {
     setIsOpenToast(!state?.status);
   }, [state]);
 
-  return { isOpenToast, handleCloseToast };
+  useEffect(() => {
+    if (isOpenToast) {
+      setTimeout(() => {
+        setMessage(`검색 오류 안내: ${state?.error}`);
+      }, 100); // 💡 약간의 지연을 주어 DOM 변경 감지
+    } else {
+      setMessage('');
+    }
+  }, [isOpenToast, state?.error]);
+
+  return { isOpenToast, handleCloseToast, errorAlertMessage: message };
 };
 
 export default useToast;

--- a/src/components/search/Searchbar/index.tsx
+++ b/src/components/search/Searchbar/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useActionState, useEffect, useRef, useState } from 'react';
+import React, { useActionState, useRef } from 'react';
 
 import { A11yMessage, Toast } from '@/components';
 import SearchIcon from '@/images/searchIcon.svg';

--- a/src/components/search/Searchbar/index.tsx
+++ b/src/components/search/Searchbar/index.tsx
@@ -54,7 +54,7 @@ const Searchbar = ({ categoryInfo, processSearch, initialFormData }: Props) => {
         <Image src={SearchIcon} alt="" width={17} height={18} />
       </button>
       {isOpenToast && (
-        <Toast handleCloseToast={handleCloseToast}>
+        <Toast handleCloseToast={handleCloseToast} a11yMessage="검색 오류 안내">
           <p>{state?.error}</p>
         </Toast>
       )}

--- a/src/components/search/Searchbar/index.tsx
+++ b/src/components/search/Searchbar/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useActionState, useRef } from 'react';
+import React, { useActionState, useEffect, useRef, useState } from 'react';
 
-import { Toast } from '@/components';
+import { A11yMessage, Toast } from '@/components';
 import SearchIcon from '@/images/searchIcon.svg';
 
 import searchAction, { ProcessSearchFunction } from './action/searchAction';
@@ -25,7 +25,7 @@ interface Props {
 const Searchbar = ({ categoryInfo, processSearch, initialFormData }: Props) => {
   const [state, formAction, isPending] = useActionState(searchAction(processSearch), null);
 
-  const { isOpenToast, handleCloseToast } = useToast({ state });
+  const { isOpenToast, handleCloseToast, errorAlertMessage } = useToast({ state });
 
   const elementId = useElementId();
 
@@ -53,8 +53,9 @@ const Searchbar = ({ categoryInfo, processSearch, initialFormData }: Props) => {
         <span className="sr-only">검색 버튼</span>
         <Image src={SearchIcon} alt="" width={17} height={18} />
       </button>
+      <A11yMessage isHidden={!isOpenToast} message={errorAlertMessage} />
       {isOpenToast && (
-        <Toast handleCloseToast={handleCloseToast} a11yMessage="검색 오류 안내">
+        <Toast handleCloseToast={handleCloseToast} a11yMessage={'검색 오류'}>
           <p>{state?.error}</p>
         </Toast>
       )}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
이 PR과 연결된 이슈 번호를 작성해주세요.  
**Closes #85**

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)
- Portal 내 tab 순환
- 알림을 자동으로 읽는 기능을 위한 A11yMessagea 컴포넌트 구현
- 토스트 : 토스트 알림이 뜨면, 스크린 리더기가 자동으로 읽어줌
- 도서 상세 정보 모달 : 도서 상세 정보 모달 안내 추가

---

## 📚 구현하면서 학습한 내용 (What I Learned)
- arial-live로 변화를 감지하기 위해서는, DOM업데이트 시간차로 상태를 업데이트하는 방법이 있다.
- 맥 보이스 오버의 경우, 자동 읽기를 켜야 토스트 뜨는 알림이 자동으로 읽힌다.
- 사용자 인터랙션이 있는 태그에만 tabIndex를 지정하는게 좋지만, 탭을 통해 사용자에게 중요한 정보를 알린다면 예외적으로 tabIndex를 사용해도 괜찮다.
---

### 😊 코멘트 💬
- 토스트 자동 읽기 기능을 구현했는데, 보이스 오버가 다른 것을 읽던 중이며 간혹 잘 안 읽힌다...
- 도서 상세 정보 모달의 경우 토스트 처럼 A11yMessage를 사용하는 것을 고려해봤지만, 모달이 읽힐 때  chilren으로 받는 모달 내용과 A11Message의 개수를 읽어줘서 사용자에게 혼란이 갈 수 있다고 생각해 Portal에 aira-label을 넣는 것으로 했다.