### PR TITLE
feat: 모달 관련 스크린 리더 설정 변경

### DIFF
--- a/src/app/book/[isbn]/_components/RelatedBooks/components/SwipeableBooksCarousel.tsx
+++ b/src/app/book/[isbn]/_components/RelatedBooks/components/SwipeableBooksCarousel.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useId } from 'react';
 
 import SwipeableCarousel from '@/components/carousel/SwipeableCarousel';
 import SwipeableBookCard from '@/components/carousel/SwipeableCarousel/components/SwipeableBookCard';
@@ -11,7 +12,7 @@ const Loaded = ({ relatedBooks }: LoadedProps) => {
   return (
     <SwipeableCarousel>
       {relatedBooks.map((book) => (
-        <li key={book.isbn}>
+        <li key={`swipeableBookCard-${book.isbn}`}>
           <Link href={`/book/${book.isbn}`}>
             <SwipeableBookCard.Loaded bookItemData={book} />
           </Link>
@@ -22,12 +23,13 @@ const Loaded = ({ relatedBooks }: LoadedProps) => {
 };
 
 const Skeleton = () => {
+  const id = useId();
   return (
     <SwipeableCarousel>
       {Array(5)
         .fill(0)
-        .map((index) => (
-          <SwipeableBookCard.Skeleton key={`swipeableBookCard-${index}`} />
+        .map((_, index) => (
+          <SwipeableBookCard.Skeleton key={`swipeableBookCard-skeleton-${id}-${index}`} />
         ))}
     </SwipeableCarousel>
   );

--- a/src/components/overlay/FullScreenModal/index.tsx
+++ b/src/components/overlay/FullScreenModal/index.tsx
@@ -30,9 +30,16 @@ const FullScreenModal = ({ children, a11yMessage }: FullScreenModalProps) => {
   }, []);
 
   return (
-    <Portal a11yMessage={a11yMessage} handleClosePortal={handleClosePortal} isFocusModal={true}>
+    <Portal handleClosePortal={handleClosePortal} isFocusFirstFocusableEl={true}>
       <div className={styles.container}>
-        <div className={styles.inner}>
+        <div
+          className={styles.inner}
+          role="dialog"
+          aria-label={a11yMessage}
+          aria-modal="true"
+          // eslint-disable-next-line
+          tabIndex={0}
+        >
           <button aria-label="닫기" className={styles.closeButton} onClick={handleClosePortal}>
             <Image src={CloseIcon} alt="" width={24} height={24} />
           </button>

--- a/src/components/overlay/FullScreenModal/index.tsx
+++ b/src/components/overlay/FullScreenModal/index.tsx
@@ -30,7 +30,7 @@ const FullScreenModal = ({ children, a11yMessage }: FullScreenModalProps) => {
   }, []);
 
   return (
-    <Portal a11yMessage={a11yMessage} handleClosePortal={handleClosePortal}>
+    <Portal a11yMessage={a11yMessage} handleClosePortal={handleClosePortal} isFocusModal={true}>
       <div className={styles.container}>
         <div className={styles.inner}>
           <button aria-label="닫기" className={styles.closeButton} onClick={handleClosePortal}>

--- a/src/components/overlay/Portal/hooks/useKeydownPortal.ts
+++ b/src/components/overlay/Portal/hooks/useKeydownPortal.ts
@@ -6,39 +6,47 @@ interface UseKeydownPortalProps {
   portalRoot: HTMLElement | null;
   modalRef: React.RefObject<HTMLDivElement | null>;
   handleClosePortal?: () => void;
+  isFocusModal?: boolean;
 }
 
-const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydownPortalProps) => {
+const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal, isFocusModal }: UseKeydownPortalProps) => {
   const [focusableElements, setFocusableElements] = useState<HTMLElement[] | null>(null);
   const focusCountRef = useRef(0);
+
+  const handleFocusModalRef = () => {
+    if (!modalRef.current || !isFocusModal) return;
+
+    modalRef.current.focus();
+    focusCountRef.current++;
+  };
+
   const updateFocusableElement = () => {
     if (!modalRef.current) return;
 
     const elements = modalRef.current.querySelectorAll<HTMLElement>(
       'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
     );
-
     setFocusableElements([modalRef.current, ...elements]);
   };
 
   const handleTab = (e: KeyboardEvent) => {
-    if (!modalRef.current) return;
     if (e.key !== 'Tab') return;
     if (!focusableElements || focusableElements.length === 0) return;
 
     const firstElement = focusableElements[0];
     const lastElement = focusableElements[focusableElements.length - 1];
-    focusCountRef.current++;
 
     if (e.shiftKey && document.activeElement === firstElement) {
       e.preventDefault();
       lastElement.focus();
     }
 
-    if (document.activeElement === lastElement || focusCountRef.current === 1) {
+    if (document.activeElement === lastElement) {
       e.preventDefault();
       firstElement.focus();
     }
+
+    focusCountRef.current++;
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -47,8 +55,11 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal }: UseKeydow
   };
 
   useEffect(() => {
+    if (!portalRoot) return;
+
     updateFocusableElement();
-  }, [portalRoot]);
+    handleFocusModalRef();
+  }, [modalRef.current, portalRoot]);
 
   useEffect(() => {
     if (!handleClosePortal) return;

--- a/src/components/overlay/Portal/hooks/useKeydownPortal.ts
+++ b/src/components/overlay/Portal/hooks/useKeydownPortal.ts
@@ -6,17 +6,22 @@ interface UseKeydownPortalProps {
   portalRoot: HTMLElement | null;
   modalRef: React.RefObject<HTMLDivElement | null>;
   handleClosePortal?: () => void;
-  isFocusModal?: boolean;
+  isFocusFirstFocusableEl?: boolean;
 }
 
-const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal, isFocusModal }: UseKeydownPortalProps) => {
+const useKeydownPortal = ({
+  portalRoot,
+  modalRef,
+  handleClosePortal,
+  isFocusFirstFocusableEl,
+}: UseKeydownPortalProps) => {
   const [focusableElements, setFocusableElements] = useState<HTMLElement[] | null>(null);
   const focusCountRef = useRef(0);
 
-  const handleFocusModalRef = () => {
-    if (!modalRef.current || !isFocusModal) return;
+  const handleFocusFirstFocusableEl = () => {
+    if (!focusableElements || !isFocusFirstFocusableEl) return;
 
-    modalRef.current.focus();
+    focusableElements[0].focus();
     focusCountRef.current++;
   };
 
@@ -26,7 +31,7 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal, isFocusModa
     const elements = modalRef.current.querySelectorAll<HTMLElement>(
       'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
     );
-    setFocusableElements([modalRef.current, ...elements]);
+    setFocusableElements([...elements]);
   };
 
   const handleTab = (e: KeyboardEvent) => {
@@ -56,10 +61,12 @@ const useKeydownPortal = ({ portalRoot, modalRef, handleClosePortal, isFocusModa
 
   useEffect(() => {
     if (!portalRoot) return;
-
     updateFocusableElement();
-    handleFocusModalRef();
   }, [modalRef.current, portalRoot]);
+
+  useEffect(() => {
+    handleFocusFirstFocusableEl();
+  }, [focusableElements, isFocusFirstFocusableEl]);
 
   useEffect(() => {
     if (!handleClosePortal) return;

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -12,14 +12,13 @@ interface Props {
   handleClosePortal?: () => void;
   children: React.ReactNode;
   extraClassName?: string;
-  a11yMessage?: string;
-  isFocusModal?: boolean;
+  isFocusFirstFocusableEl?: boolean;
 }
-const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage, isFocusModal = false }: Props) => {
+const Portal = ({ handleClosePortal, children, extraClassName, isFocusFirstFocusableEl = false }: Props) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
-  useKeydownPortal({ modalRef, portalRoot, handleClosePortal, isFocusModal });
+  useKeydownPortal({ modalRef, portalRoot, handleClosePortal, isFocusFirstFocusableEl });
   useClickPortal({ modalRef, handleClosePortal });
 
   useEffect(() => {
@@ -30,15 +29,7 @@ const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage, isFo
   if (!portalRoot) return null; // portal-root가 준비되지 않으면 렌더링하지 않음
 
   return createPortal(
-    <div
-      role="dialog"
-      aria-label={a11yMessage ?? 'portal'}
-      aria-modal="true"
-      ref={modalRef}
-      className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}
-      //eslint-disable-next-line
-      tabIndex={0}
-    >
+    <div ref={modalRef} className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}>
       {children}
     </div>,
     portalRoot,

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -32,6 +32,7 @@ const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage }: Pr
     <div
       role="dialog"
       aria-label={a11yMessage ?? 'portal'}
+      aria-modal="true"
       ref={modalRef}
       className={classNames(styles.portal, { [extraClassName as string]: extraClassName })}
       //eslint-disable-next-line

--- a/src/components/overlay/Portal/index.tsx
+++ b/src/components/overlay/Portal/index.tsx
@@ -13,12 +13,13 @@ interface Props {
   children: React.ReactNode;
   extraClassName?: string;
   a11yMessage?: string;
+  isFocusModal?: boolean;
 }
-const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage }: Props) => {
+const Portal = ({ handleClosePortal, children, extraClassName, a11yMessage, isFocusModal = false }: Props) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
-  useKeydownPortal({ modalRef, portalRoot, handleClosePortal });
+  useKeydownPortal({ modalRef, portalRoot, handleClosePortal, isFocusModal });
   useClickPortal({ modalRef, handleClosePortal });
 
   useEffect(() => {

--- a/src/components/overlay/Toast/index.tsx
+++ b/src/components/overlay/Toast/index.tsx
@@ -28,8 +28,8 @@ const Toast = ({ children, handleCloseToast, a11yMessage }: Props) => {
   }, []);
 
   return (
-    <Portal a11yMessage={a11yMessage}>
-      <div className={styles.toast}>
+    <Portal>
+      <div role="alert" aria-label={a11yMessage} aria-live="assertive" className={styles.toast}>
         <Image src={WarningIcon} alt="" width={16} />
         {children}
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
이 PR과 연결된 이슈 번호를 작성해주세요.  
**Closes #92**

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)
###  모달, 토스트 aria 개별 처리로 변경
구현 배경: 모달 활성화 시, 모달 aira-label을 자동으로 읽지 못하는 오류 수정 

변경 이유:
- 모달, 토스트의 역할이 달라서 둘의 role이 달라야하고, 자동으로 읽어주기 위해서 
- 토스트: role="alert", aria-live="assertive"를 사용 
- 모달 :  role='dialog'와 aria-modal='true' 를 사용하고, 포커스를 주어서 자동으로 읽게 처리 
  
---

## 📚 구현하면서 학습한 내용 (What I Learned)
### 왜 role='dialog'와 aira-live='assertive'를 같이 사용하면 안될까? 
 이유: dialog와 aria-live는 의미적으로 충돌하기 때문

**🤔 role="dialog"란?**
- 사용자와의 상호작용(Interaction)이 필요한 포커스 기반 컨테이너
- 페이지의 주요 콘텐츠와 분리된 별도의 영역으로, **사용자의 집중을 유도하고 상호 작용을 요구할 때 사용**
- 보통 사용자에게 보여지고 → 포커스를 주고 → 사용자가 읽고 조작하게 하는 구조

=>  스크린 리더는 "이걸 바로 읽지 않고, 포커스가 이동해야 유효하다"고 간주함

**🤔 aria-live="assertive"란?**
- 자동으로 읽혀야 하는 **실시간 알림 영역을 나타냄**
- 포커스 없이도 DOM 변경이 있으면 즉시 읽음
- 대표적인 사용: 토스트, 경고 메시지, 실시간 피드백

💡 WAI-ARIA 공식 권장 사항
**aria-live**는 alert, status, log 등 **실시간 알림에 적합**하고, **dialog, modal 같은 구조적 역할에는 사용하지 말라**고 명시됨.

---

### 😊 코멘트 💬
- 더 파보고 블로그 글 적어봐야지 
