### PR TITLE
fix: 공공 데이터에 찾는 데이터 값이 없을 때, 데이터 매핑 오류 수정 

### DIFF
--- a/src/app/(home)/_services/books.ts
+++ b/src/app/(home)/_services/books.ts
@@ -7,7 +7,7 @@ export const getRisingBooks = async () => {
 
   const { response } = data;
 
-  if (response.resultNum === 0) return [];
+  if (!('result' in response.results[0])) return [];
 
   const books = response.results[0].result.docs.map(({ doc }: { doc: NaruApiBookData }) => {
     return formatNaruApiBookDataToBookItemData(doc);

--- a/src/app/(home)/_services/books.ts
+++ b/src/app/(home)/_services/books.ts
@@ -5,7 +5,11 @@ import { formatNaruApiBookDataToBookItemData } from '@/utils/bookDataFormatter';
 export const getRisingBooks = async () => {
   const data = await fetchRisingBooks();
 
-  const books = data.response.results[0].result.docs.map(({ doc }: { doc: NaruApiBookData }) => {
+  const { response } = data;
+
+  if (response.resultNum === 0) return [];
+
+  const books = response.results[0].result.docs.map(({ doc }: { doc: NaruApiBookData }) => {
     return formatNaruApiBookDataToBookItemData(doc);
   });
 

--- a/src/app/book/[isbn]/_services/book.ts
+++ b/src/app/book/[isbn]/_services/book.ts
@@ -15,6 +15,10 @@ export const getBookDetails = async (isbn: string) => {
 
 export const getBooksForMania = async (isbn: string) => {
   const data = await fetchBooksForMania(isbn);
+  const { response } = data;
+
+  if (response.resultNum === 0) return [];
+
   const books: BookItemData[] = data.response.docs.map(({ book }: { book: NaruApiBookData }) =>
     formatNaruApiBookDataToBookItemData(book),
   );

--- a/src/services/books/bookList.ts
+++ b/src/services/books/bookList.ts
@@ -29,16 +29,15 @@ export const fetchPopularBooks = async (props: GetPopularBooksParamsProps) => {
  */
 export const getPopularBooks = async (props: GetPopularBooksParamsProps) => {
   const data = await fetchPopularBooks(props);
-  const { resultNum } = data.response;
 
-  if (resultNum === 0)
+  if (!('docs' in data.response))
     return {
       books: [],
       isLastPage: true,
       totalBooksLength: 0,
     };
 
-  const { docs, numFound } = data.response;
+  const { docs, numFound, resultNum } = data.response;
 
   const books = docs.map(({ doc }: { doc: NaruApiBookData }) => {
     return formatNaruApiBookDataToBookItemData(doc);

--- a/src/services/books/bookList.ts
+++ b/src/services/books/bookList.ts
@@ -29,7 +29,17 @@ export const fetchPopularBooks = async (props: GetPopularBooksParamsProps) => {
  */
 export const getPopularBooks = async (props: GetPopularBooksParamsProps) => {
   const data = await fetchPopularBooks(props);
-  const { docs, numFound, resultNum } = data.response;
+  const { resultNum } = data.response;
+
+  if (resultNum === 0)
+    return {
+      books: [],
+      isLastPage: true,
+      totalBooksLength: 0,
+    };
+
+  const { docs, numFound } = data.response;
+
   const books = docs.map(({ doc }: { doc: NaruApiBookData }) => {
     return formatNaruApiBookDataToBookItemData(doc);
   });

--- a/src/services/books/librarianPick.ts
+++ b/src/services/books/librarianPick.ts
@@ -48,12 +48,15 @@ const handleLastMonthLibrarianPickError = (data: any) => {
  * @returns 지난달 사서 추천 도서 목록 포맷팅 데이터
  */
 const formatLastMonthLibrarianPick = (data: any) => {
-  const {
-    channel: { list },
-  } = data;
+  const { channel } = data;
+
+  if (channel.totalCount === 0) {
+    return [];
+  }
+
   const MAX_CONTENT_LENGTH = 100;
 
-  const result: BookSimpleInfo[] = list.map(({ item }: ApiLibrarianPickData) => {
+  const result: BookSimpleInfo[] = channel.list.map(({ item }: ApiLibrarianPickData) => {
     let author = item.recomauthor.replace('지음', '').trim();
     let translator;
 


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
이 PR과 연결된 이슈 번호를 작성해주세요.  
**Closes #94 **

---

## 💡 어떤 것, 어떻게 해결했는가? (What & How)
- 이슈 : 공공 데이터에서 찾는 데이터가 없을 경우, 데이터 응답 형식이 달라서 클라이언트에서 필요한 데이터로 매핑 시 오류 발생 
- 해결 :  데이터 없을 경우, 빈 배열로 반환하는 방어 로직 추가
  - resultNum처럼 데이터 없을 경우 이를 표기하는 속성을 확인되면 해당 속성 활용
  - 그렇지 않은 경우, 데이터 있을 경우 표기회는 속성이 응답 데이터에 존재하는 지 확인  
---

## 📚 구현하면서 학습한 내용 (What I Learned)


---

### 😊 코멘트 💬
- API 문서 어디없나... 
